### PR TITLE
Es6 export

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -4,7 +4,7 @@
 
 var minimist = require('minimist')
 
-var argv = minimist(process.argv.slice(2))
+var argv = minimist(process.argv.slice(2), {boolean: true})
 
 var stdin = process.stdin
 var stdout = process.stdout
@@ -17,7 +17,7 @@ stdin.on('data', function (text) {
   buffer += text
 })
 stdin.on('end', function () {
-  stdout.write(superviews(buffer, argv.name, argv.argstr))
+  stdout.write(superviews(buffer, argv.name, argv.argstr, (argv.es6) ? argv.es6 : false))
 })
 
 stdin.resume()

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ module.exports = function (tmplstr, name, argstr, es6) {
   result = 'function ' + name + ' (' + args + ') {\n' + result + '\n}'
 	
 	if (es6) {
-		result = 'export ' + result
+		result = "import { patch, elementOpen, elementClose, text } from 'incremental-dom' \n\nexport " + result
 	}
 
   flush()

--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ var handler = {
   }
 }
 
-module.exports = function (tmplstr, name, argstr) {
+module.exports = function (tmplstr, name, argstr, es6) {
   flush()
 
   var parser = new htmlparser.Parser(handler, {
@@ -199,7 +199,12 @@ module.exports = function (tmplstr, name, argstr) {
     return item.trim()
   }).join(', ')
 
+
   result = 'function ' + name + ' (' + args + ') {\n' + result + '\n}'
+	
+	if (es6) {
+		result = 'export ' + result
+	}
 
   flush()
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build:test": "cat test/tmpl.html | ./bin/cmd.js > test/tmpl.js",
+    "build:test-es6": "cat test/tmpl.html | ./bin/cmd.js --es6 > test/tmpl.js",
     "lint": "standard index.js bin/cmd.js",
     "build:readme": "cat test/readme.html | ./bin/cmd.js > test/readme.js"
   },


### PR DESCRIPTION
added --es6 flag to make the output of the tool easier to import in es6 transpiled code...

Not sure if this is how you would have done it but I am using this on one of my projects to make the output from your tool importable in a babel transpiled project.

Nice work on this project btw!  Thanks for making this, hope this pull request is useful to someone.