### PR TITLE
Preserve attribute and tag name case

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,8 @@ module.exports = function (tmplstr, name, argstr) {
   flush()
 
   var parser = new htmlparser.Parser(handler, {
-    decodeEntities: false
+    decodeEntities: false,
+    lowerCaseAttributeNames: false
   })
 
   parser.write(tmplstr)

--- a/index.js
+++ b/index.js
@@ -185,7 +185,8 @@ module.exports = function (tmplstr, name, argstr) {
 
   var parser = new htmlparser.Parser(handler, {
     decodeEntities: false,
-    lowerCaseAttributeNames: false
+    lowerCaseAttributeNames: false,
+    lowerCaseTags: false
   })
 
   parser.write(tmplstr)


### PR DESCRIPTION
This caused  a problem for me when using `svg` in `html`, as `svg` attributes and tag names are case sensitive.