### PR TITLE
Add whitespace between hoisted and export in es6

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,7 +317,7 @@ module.exports = function (tmplstr, name, argstr, mode) {
       break
     case 'es6':
       result = 'import {patch, elementOpen, elementClose, text, skip, currentElement} from "incremental-dom"\n\n'
-      result += hoisted + 'export ' + fn + '\n'
+      result += hoisted + '\n\n' + 'export ' + fn + '\n'
       break
     case 'cjs':
       result = 'var IncrementalDOM = require(\'incremental-dom\')\n' +


### PR DESCRIPTION
`hoisted` variables had no whitespace separating them from `export` in `es6` mode, causing variables to be interpolated with `export` (ie: `var __targetexport function`).

This fixes `es6` mode, which was previously unusable.