### PR TITLE
Remove carriage return in interpolate function

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ function interpolate (text) {
   text = text.replace(/\{/g, '" + (')
   text = text.replace(/\}/g, ') + "')
   text = text.replace(/\n/g, ' \\\n')
+  text = text.replace(/\r/g, '')
   return strify(text)
 }
 


### PR DESCRIPTION
Under windows, superviews is creating invalid code for multi line strings. 

This is the result of running `npm run build:readme`:

```
text("
     \
        My name is " + (data.name) + " my age is " + (data.age) + "
     \
        I live at " + (data.address) + "
     \

     \
        ")
```

This occurs because carriage return was not being take into account

This PR fixes it